### PR TITLE
Fix the redis cache spec to construct the cache with the anticipated ttl

### DIFF
--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -25,17 +25,26 @@ describe('RedisCacheAdapter', function() {
   });
 
   it('should expire after ttl', (done) => {
-    var cache = new RedisCacheAdapter({
-      ttl: 100
-    });
+    var cache = new RedisCacheAdapter(null, 1);
 
     cache.put(KEY, VALUE)
       .then(() => cache.get(KEY))
       .then((value) => expect(value).toEqual(VALUE))
-      .then(wait.bind(null, 1000))
+      .then(wait.bind(null, 2))
       .then(() => cache.get(KEY))
       .then((value) => expect(value).toEqual(null))
       .then(done);
-  })
+  });
 
+  it('should find un-expired records', (done) => {
+    var cache = new RedisCacheAdapter(null, 5);
+
+    cache.put(KEY, VALUE)
+      .then(() => cache.get(KEY))
+      .then((value) => expect(value).toEqual(VALUE))
+      .then(wait.bind(null, 1))
+      .then(() => cache.get(KEY))
+      .then((value) => expect(value).not.toEqual(null))
+      .then(done);
+  });
 });

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -1,7 +1,7 @@
 import redis from 'redis';
 import logger from '../../logger';
 
-const DEFAULT_REDIS_TTL = 30000; // 30 seconds in milliseconds
+const DEFAULT_REDIS_TTL = 30 * 1000; // 30 seconds in milliseconds
 
 function debug() {
   logger.debug.apply(logger, ['RedisCacheAdapter', ...arguments]);


### PR DESCRIPTION
also make timeout values really really small so our test runs fast :).

hi @f0ster!

Your pr for the redis ttl had failing tests.

I couldn't spot the error, so I checked out your branch and focused on the the failing test.

You can see in this pr what the issue was,  the redis cache constructor wont handle an object parameter, it is expecting two arguments.

Since I was already in there, I also switched back the Default TTL comment cause I just prefer the way it was before :) hope that's ok.

If this all looks right to you, you can merge this pull request into your repo and then you can push your master to the parse-server repo and the open PR should update.  presto!
